### PR TITLE
Use allocate() instead of createAccount() if withdraw amount > rent exempt

### DIFF
--- a/src/stake-pool/utils.ts
+++ b/src/stake-pool/utils.ts
@@ -479,15 +479,19 @@ export async function getWithdrawStakeTransactions(
       // create blank stake account
       const stakeSplitTo = Keypair.generate();
       newStakeAccounts.push(stakeSplitTo);
-      tx.add(
-        SystemProgram.createAccount({
-          fromPubkey: walletPubkey,
-          lamports: lamportsReqStakeAcc,
-          newAccountPubkey: stakeSplitTo.publicKey,
-          programId: StakeProgram.programId,
-          space: STAKE_STATE_LEN,
-        }),
-      );
+      const txInstruction = dropletsUnstaked.gt(new BN(lamportsReqStakeAcc))
+        ? SystemProgram.allocate({
+            accountPubkey: walletPubkey,
+            space: STAKE_STATE_LEN,
+          })
+        : SystemProgram.createAccount({
+            fromPubkey: walletPubkey,
+            lamports: lamportsReqStakeAcc,
+            newAccountPubkey: stakeSplitTo.publicKey,
+            programId: StakeProgram.programId,
+            space: STAKE_STATE_LEN,
+          });
+      tx.add(txInstruction);
       // The tx also needs to be signed by the new stake account's private key
       signers.push(stakeSplitTo);
 


### PR DESCRIPTION
closes #111 

some tests are failing for some reason, but turned out they fail even without this change